### PR TITLE
Compare command

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GEM
     activerecord (2.3.10)
       activesupport (= 2.3.10)
     activesupport (2.3.10)
-    configuration (1.1.0)
+    configuration (1.2.0)
     highline (1.5.2)
     json (1.4.6)
     launchy (0.3.7)

--- a/lib/commands/commands.rb
+++ b/lib/commands/commands.rb
@@ -264,3 +264,21 @@ command :search do |query|
     puts "No results found"
   end
 end
+
+desc 'Display the URL to the compare view for the given tree-ish objects'
+usage "github compare [start treeish] [end treeish]"
+usage "github compare [end treeish]"
+flags :open => "Open the compare view in a browser"
+command :compare do |start_tree, end_tree|
+  unless end_tree # only start given. assume starting from master, and ending at start_end
+    end_tree = start_tree
+    start_tree = 'master'
+  end
+
+  compare_url = helper.compare_for(helper.owner, start_tree, end_tree)
+  if options[:open]
+    helper.open compare_url
+  else
+    puts compare_url
+  end
+end

--- a/lib/commands/commands.rb
+++ b/lib/commands/commands.rb
@@ -270,10 +270,12 @@ usage "github compare [start treeish] [end treeish]"
 usage "github compare [end treeish]"
 flags :open => "Open the compare view in a browser"
 command :compare do |start_tree, end_tree|
-  unless end_tree # only start given. assume starting from master, and ending at start_end
-    end_tree = start_tree
-    start_tree = 'master'
+  unless end_tree # only end given. assume starting from current branch, and ending at start_end
+    start_tree, end_tree = helper.branch, start_tree
   end
+
+  start_tree = helper.branch_to_compareish(start_tree)
+  end_tree = helper.branch_to_compareish(end_tree)
 
   compare_url = helper.compare_for(helper.owner, start_tree, end_tree)
   if options[:open]

--- a/lib/commands/commands.rb
+++ b/lib/commands/commands.rb
@@ -274,6 +274,9 @@ command :compare do |start_tree, end_tree|
     start_tree, end_tree = helper.branch, start_tree
   end
 
+  start_tree = helper.branch if start_tree == '-'
+  end_tree = helper.branch if end_tree == '-'
+
   start_tree = helper.branch_to_compareish(start_tree)
   end_tree = helper.branch_to_compareish(end_tree)
 

--- a/lib/commands/helpers.rb
+++ b/lib/commands/helpers.rb
@@ -27,6 +27,14 @@ helper :origin do
   orig || 'origin'
 end
 
+helper :branch do
+  # zomg hax. groks output like:
+  # * compare
+  #   master
+  `git branch --no-color`.split("\n").detect {|line| line =~ /^\* (.*)$/ }
+  $1
+end
+
 helper :project do
   repo = repo_for(origin)
   if repo.nil? || repo.empty?
@@ -496,3 +504,15 @@ helper :print_issues do |issues, options|
   end
   puts "-----"
 end
+
+helper :branch_to_compareish do |branch|
+  if branch =~ %r{^\w+/\w+$} # like origin/master
+    remote, branch = branch.split('/')
+    user = user_for(remote)
+
+    "#{user}:#{branch}"
+  else # it's probably alright
+    branch
+  end
+end
+

--- a/lib/commands/helpers.rb
+++ b/lib/commands/helpers.rb
@@ -256,6 +256,10 @@ helper :issues_page_for do |user|
   "https://github.com/#{user}/#{project}/issues"
 end
 
+helper :compare_for do |user, start_tree, end_tree|
+  "https://github.com/#{user}/#{project}/compare/#{start_tree}...#{end_tree}"
+end
+
 helper :list_issues_for do |user, state|
   "https://github.com/api/v2/yaml/issues/list/#{user}/#{project}/#{state}"
 end

--- a/spec/commands/command_compare_spec.rb
+++ b/spec/commands/command_compare_spec.rb
@@ -46,4 +46,28 @@ describe "github compare" do
       @helper.should_receive('open').with(compare_url)
     end
   end
+
+  specify "it can fill in '-' with the current branch for start point" do
+    running :compare, 'fallthrough', '-' do
+      @helper.should_receive(:branch).and_return('compare')
+      setup_url_for "origin", "defunkt", "github-gem"
+
+      compare_url = 'awesome'
+      @helper.should_receive(:compare_for).with('defunkt', 'fallthrough', 'compare').and_return(compare_url)
+
+      stdout.should == 'awesome'
+    end
+  end
+
+  specify "it can fill in '-' with the current branch for end point" do
+    running :compare, '-', 'fallthrough' do
+      @helper.should_receive(:branch).and_return('compare')
+      setup_url_for "origin", "defunkt", "github-gem"
+
+      compare_url = 'awesome'
+      @helper.should_receive(:compare_for).with('defunkt', 'compare', 'fallthrough').and_return(compare_url)
+
+      stdout.should == 'awesome'
+    end
+  end
 end

--- a/spec/commands/command_compare_spec.rb
+++ b/spec/commands/command_compare_spec.rb
@@ -1,0 +1,46 @@
+require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
+require File.dirname(__FILE__) + '/command_helper'
+
+describe "github compare" do
+  include CommandHelper
+
+  context "when given two treeish objects" do
+    specify "it opens the compare view between the two objects" do
+      running :compare, 'gist', 'fallthrough' do
+        setup_url_for "origin", "defunkt", "github-gem"
+
+        compare_url = 'awesome'
+        @helper.should_receive(:compare_for).with('defunkt', 'gist', 'fallthrough').and_return(compare_url)
+
+        @helper.should_not_receive(:open)
+        stdout.should == 'awesome'
+      end
+    end
+  end
+
+  context "when given one treeish object" do
+    specify "it opens the compare view between master and the object" do
+      running :compare, 'fallthrough' do
+        setup_url_for "origin", "defunkt", "github-gem"
+
+        compare_url = 'awesome'
+        @helper.should_receive(:compare_for).with('defunkt', 'master', 'fallthrough').and_return(compare_url)
+
+        @helper.should_not_receive(:open)
+        stdout.should == 'awesome'
+      end
+    end
+  end
+
+  specify "it can open the URL in a browser" do
+    running :compare, 'fallthrough', '--open' do
+      setup_url_for "origin", "defunkt", "github-gem"
+
+      compare_url = 'awesome'
+      @helper.should_receive(:compare_for).with('defunkt', 'master', 'fallthrough').and_return(compare_url)
+
+      stdout.should_not == 'awesome'
+      @helper.should_receive('open').with(compare_url)
+    end
+  end
+end

--- a/spec/commands/command_compare_spec.rb
+++ b/spec/commands/command_compare_spec.rb
@@ -19,10 +19,11 @@ describe "github compare" do
   end
 
   context "when given one treeish object" do
-    specify "it opens the compare view between master and the object" do
+    specify "it opens the compare view between current branch and the object" do
       running :compare, 'fallthrough' do
         setup_url_for "origin", "defunkt", "github-gem"
 
+        @helper.should_receive(:branch).and_return('master')
         compare_url = 'awesome'
         @helper.should_receive(:compare_for).with('defunkt', 'master', 'fallthrough').and_return(compare_url)
 
@@ -35,6 +36,8 @@ describe "github compare" do
   specify "it can open the URL in a browser" do
     running :compare, 'fallthrough', '--open' do
       setup_url_for "origin", "defunkt", "github-gem"
+
+      @helper.should_receive(:branch).and_return('master')
 
       compare_url = 'awesome'
       @helper.should_receive(:compare_for).with('defunkt', 'master', 'fallthrough').and_return(compare_url)

--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -365,4 +365,11 @@ random
       @helper.open "http://www.google.com"
     end
   end
+
+  helper :compare_for do
+    it "should generate correct URL" do
+      setup_url_for "origin", "defunkt", "github-gem"
+      @helper.compare_for('defunkt', 'master', 'fallthrough').should == "https://github.com/defunkt/github-gem/compare/master...fallthrough"
+    end
+  end
 end

--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -372,4 +372,24 @@ random
       @helper.compare_for('defunkt', 'master', 'fallthrough').should == "https://github.com/defunkt/github-gem/compare/master...fallthrough"
     end
   end
+
+  helper :branch do
+    it "detects the correct branch" do
+      setup_url_for "origin", "defunkt", "github-gem"
+      @helper.should_receive(:`).with("git branch --no-color").and_return("* compare\n  master\n")
+      @helper.branch.should == 'compare'
+    end
+  end
+
+  helper :branch_to_compareish do
+    it "converts a remote branch to user:repository syntax" do
+      @helper.should_receive(:user_for).with('upstream').and_return('defunkt')
+
+      @helper.branch_to_compareish('upstream/master').should == 'defunkt:master'
+    end
+
+    it "doesn't convert anything else" do
+      @helper.branch_to_compareish('compare').should == 'compare'
+    end
+  end
 end

--- a/spec/resources/help_output.txt
+++ b/spec/resources/help_output.txt
@@ -8,6 +8,11 @@ Available commands:
                        --search: Search for [user|repo] and clone selected
                          repository
                        --ssh : Clone using the git@github.com style url.
+  compare           => Display the URL to the compare view for the given
+                       tree-ish objects
+                       % github compare [start treeish] [end treeish]
+                       % github compare [end treeish]
+                       --open: Open the compare view in a browser
   config            => Automatically set configuration info, or pass args to
                        specify.
                        % github config [my_username] [my_repo_name]


### PR DESCRIPTION
I heart the compare view, but I have a hell of a time both finding it in the UI and remembering the exact format of the URL. Therefore, it'd be nice to have a command to make it a non-issue to remember:

```
gh compare my-awesome-sauce                     # => https://github.com/user/repo/compare/master...my-awesome-sauce
gh compare lame-sauce my-awesome-sauce   # => https://github.com/user/repo/compare/lame-sauce...my-awesome-sauce
```

These only print the URL. If you want to open it in a browser, using launchy, you just toss on an `--open`:

```
gh compare my-awesome-sauce --open
```

Right now, it's pretty naive in how it generates the compare URL. That is, the args to `gh` are put directly in the URL. I have some crazy ideas brewing though where you would be able to pass it treeish objects in your local repos (ie branch quantified by remote), and it'd do the trickery to convert that to the URL syntax. For example, if I had a remote called upstream that pointed at the trogdor user, you might do this:

```
gh compare upstream/my-awesome-sauce                     # => https://github.com/user/repo/compare/master...trogdor:my-awesome-sauce
```

Not quite there yet though, so definitely open to feedback!
