### PR TITLE
force text-hyphen 1.0.0 dependency for Ruby >= 1.9

### DIFF
--- a/github.gemspec
+++ b/github.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
   
+  s.add_dependency "text-hyphen", "1.0.0"
   s.add_dependency "text-format", "1.0.0"
   s.add_dependency "highline", "~> 1.5.1"
   s.add_dependency "json", "~> 1.4.6"

--- a/github.gemspec
+++ b/github.gemspec
@@ -19,8 +19,6 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
   
-  s.add_dependency "text-hyphen", "1.0.0"
-  s.add_dependency "text-format", "1.0.0"
   s.add_dependency "highline", "~> 1.5.1"
   s.add_dependency "json", "~> 1.4.6"
   s.add_dependency "launchy", "~> 0.3.7"


### PR DESCRIPTION
Hey all,

In addition to setting text-format to 1.0.0 so that it will install in ruby >= 1.9, text-hyphen needs to be hard set as well, as text-format has it ~>1.0.0. thanks!
