### PR TITLE
Creating repositories that contains whitespace

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GEM
     activerecord (2.3.10)
       activesupport (= 2.3.10)
     activesupport (2.3.10)
-    configuration (1.1.0)
+    configuration (1.2.0)
     highline (1.5.2)
     json (1.4.6)
     launchy (0.3.7)
@@ -23,7 +23,7 @@ GEM
     rspec (1.3.1)
     text-format (1.0.0)
       text-hyphen (~> 1.0.0)
-    text-hyphen (1.0.0)
+    text-hyphen (1.0.2)
 
 PLATFORMS
   ruby

--- a/lib/commands/commands.rb
+++ b/lib/commands/commands.rb
@@ -193,7 +193,7 @@ flags :rdoc => 'Create README.rdoc'
 flags :rst => 'Create README.rst'
 flags :private => 'Create private repository'
 command :create do |repo|
-  sh "curl -F 'repository[name]=#{repo}' -F 'repository[public]=#{!options[:private]}' -F 'login=#{github_user}' -F 'token=#{github_token}' https://github.com/repositories"
+  data = sh "curl -F 'repository[name]=#{repo}' -F 'repository[public]=#{!options[:private]}' -F 'login=#{github_user}' -F 'token=#{github_token}' https://github.com/repositories"
   mkdir repo
   cd repo
   git "init"
@@ -201,6 +201,7 @@ command :create do |repo|
   touch extension ? "README.#{extension}" : "README"
   git "add *"
   git "commit -m 'First commit!'"
+  repo = $1 if data =~ /"https:\/\/github.com\/#{github_user}\/(.+?)"/i
   git "remote add origin git@github.com:#{github_user}/#{repo}.git"
   git_exec "push origin master"
 end

--- a/spec/commands/command_create_spec.rb
+++ b/spec/commands/command_create_spec.rb
@@ -1,0 +1,24 @@
+require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
+require File.dirname(__FILE__) + '/command_helper'
+
+describe "github create" do
+  include CommandHelper
+  it "should use the repo name given by github, not the user" do
+    running :create, "My Super Repo" do
+      setup_github_token
+      @command.should_receive(:sh).
+        with("curl -F 'repository[name]=My Super Repo' -F 'repository[public]=true' -F 'login=drnic' -F 'token=MY_GITHUB_TOKEN' https://github.com/repositories").
+        once.
+        and_return("<html><body>You are being <a href=\"https://github.com/drnic/My-Super-Repo\">redirected</a>.</body></html>")
+        
+      @command.should_receive(:mkdir).with("My Super Repo").once
+      @command.should_receive(:cd).with("My Super Repo").once
+      @command.should_receive(:git).with("init").once
+      @command.should_receive(:touch).with("README").once
+      @command.should_receive(:git).with("add *").once
+      @command.should_receive(:git).with("commit -m 'First commit!'").once
+      @command.should_receive(:git).with("remote add origin git@github.com:drnic/My-Super-Repo.git").once
+      @command.should_receive(:git_exec).with("push origin master").once
+    end
+  end
+end


### PR DESCRIPTION
It now works to create a repo that contains whitespace.

Before, the ingoing argument was used as the name of the repo.
Now I'm using the repo name that is being returned from Github.

```
github create "My Repo"
=> git@github.com:oleander/My-Repo.git
```
