### PR TITLE
Get github credentials from environment if they are not found in git config

### DIFF
--- a/lib/commands/helpers.rb
+++ b/lib/commands/helpers.rb
@@ -492,3 +492,8 @@ helper :print_issues do |issues, options|
   end
   puts "-----"
 end
+
+helper :getenv do |var|
+  ENV[var]
+end
+

--- a/lib/github/command.rb
+++ b/lib/github/command.rb
@@ -67,7 +67,10 @@ module GitHub
     end
 
     def github_user
-      user = git("config --get github.user")
+      user = [
+        git("config --get github.user"),
+        helper.getenv("GITHUB_USER")
+      ].reject { |s| s == nil or s.empty? }.first || ""
       if user.empty?
         request_github_credentials
         user = github_user
@@ -76,7 +79,10 @@ module GitHub
     end
 
     def github_token
-      token = git("config --get github.token")
+      token = [
+        git("config --get github.token"),
+        helper.getenv("GITHUB_TOKEN")
+      ].reject { |s| s == nil or s.empty? }.first || ""
       if token.empty?
         request_github_credentials
         token = github_token

--- a/spec/command_spec.rb
+++ b/spec/command_spec.rb
@@ -82,6 +82,9 @@ describe GitHub::Command do
   
   it "requests github API credentials if not found" do
     @command.should_receive(:git).once.with("config --get github.user").and_return("")
+    helper = mock("GitHub::Helper")
+    helper.should_receive("getenv").twice.with("GITHUB_USER").and_return("")
+    @command.should_receive(:helper).twice.and_return(helper)
     @command.should_receive(:puts).once.with("Please enter your GitHub credentials:")
     h = mock("HighLine")
     h.should_receive(:ask).once.with("Username: ").and_return("drnic")
@@ -97,15 +100,16 @@ describe GitHub::Command do
 
   it "requests github API credentials if not found, and shows accounts page" do
     @command.should_receive(:git).once.with("config --get github.user").and_return("")
+    helper = mock("GitHub::Helper")
+    @command.should_receive(:helper).exactly(3).and_return(helper)
+    helper.should_receive("getenv").twice.with("GITHUB_USER").and_return("")
     @command.should_receive(:puts).once.with("Please enter your GitHub credentials:")
     h = mock("HighLine")
     h.should_receive(:ask).once.with("Username: ").and_return("drnic")
     @command.should_receive(:puts).once.with("Your account token is at https://github.com/account under 'Account Admin'.")
     @command.should_receive(:puts).once.with("Press Enter to launch page in browser.")
     h.should_receive(:ask).once.with("Token: ").and_return("")
-    helper = mock("GitHub::Helper")
     helper.should_receive("open").once.with("https://github.com/account")
-    @command.should_receive(:helper).once.and_return(helper)
     h.should_receive(:ask).once.with("Token: ").and_return("TOKEN")
     @command.should_receive(:highline).any_number_of_times.and_return(h)
     @command.should_receive(:git).once.with("config --global github.user 'drnic'")

--- a/spec/command_spec.rb
+++ b/spec/command_spec.rb
@@ -113,4 +113,22 @@ describe GitHub::Command do
     @command.should_receive(:git).once.with("config --get github.user").and_return("drnic")
     @command.github_user
   end
+
+  it "gets the github username from the environment if not found in the config" do
+    @command.should_receive(:git).once.with("config --get github.user").and_return("")
+    @command.should_not_receive(:puts)
+    helper = mock("GitHub::Helper")
+    helper.should_receive("getenv").once.with("GITHUB_USER").and_return("drnic")
+    @command.should_receive(:helper).once.and_return(helper)
+    @command.github_user
+  end
+
+  it "gets the github tokenname from the environment if not found in the config" do
+    @command.should_receive(:git).once.with("config --get github.token").and_return("")
+    @command.should_not_receive(:puts)
+    helper = mock("GitHub::Helper")
+    helper.should_receive("getenv").once.with("GITHUB_TOKEN").and_return("TOKEN")
+    @command.should_receive(:helper).once.and_return(helper)
+    @command.github_token
+  end
 end


### PR DESCRIPTION
Hiya,

Here's a little something that allows github to use GITHUB_USER and GITHUB_TOKEN environment variables as alternatives to the git config keys github.user and github.token. I wrote this up when I realized I might in some cases want to version control my ~/.gitconfig. Hope you find it useful.
