### PR TITLE
switch deprecated Launchy API call

### DIFF
--- a/lib/commands/helpers.rb
+++ b/lib/commands/helpers.rb
@@ -272,7 +272,7 @@ end
 
 helper :open do |url|
   has_launchy? proc {
-    Launchy::Browser.new.visit url
+    Launchy.open url
   }
 end
 


### PR DESCRIPTION
This fix stops Launchy deprecation warnings when running github browse
