### PR TITLE
github create & github config

### DIFF
--- a/lib/github.rb
+++ b/lib/github.rb
@@ -9,6 +9,7 @@ require 'open-uri'
 require 'json'
 require 'yaml'
 require 'text/format'
+require 'logger'
 
 ##
 # Starting simple.

--- a/lib/github.rb
+++ b/lib/github.rb
@@ -9,7 +9,6 @@ require 'open-uri'
 require 'json'
 require 'yaml'
 require 'text/format'
-require 'logger'
 
 ##
 # Starting simple.


### PR DESCRIPTION
Two issues I found and fixed.  The first was with github create, which now sends the json request to the API along with the name.  It was correct in `create-from-local` but not `create`.  Also I set the creation of the local git repo conditional to the success of the curl request.  

The second was with `github config`; overriding the global github.user with the username of the current ENV (`whoami`).

This was all working with `ruby 1.9.3p125`. 
