### PR TITLE
"gh open" without any args opens up the current repo page

### DIFF
--- a/lib/commands/commands.rb
+++ b/lib/commands/commands.rb
@@ -46,6 +46,12 @@ end
 desc 'Open the given user/project in a web browser'
 usage 'github open [user/project]'
 command :open do |arg|
+  if arg.nil?
+    origin = git('remote -v').split("\n").find{|i| i =~ /^origin/ }
+    if origin
+      arg = origin.split(/\s/)[1].sub('git@github.com:','').sub('https://github.com/','').sub('.git','')
+    end
+  end
   helper.open "https://github.com/#{arg}"
 end
 


### PR DESCRIPTION
Right now, `gh open` (no args) will lead us to the github top page. It is rather useless.

With this change, the same command will bring us to the origin's top page, when and only when you're in the repo's directory. If you're not in any repo, defaults to the previous behavior - go to https://github.com.

It is convenient when you have a prettified README.md as a quick reference for the project.
