### PR TITLE
added support for the compare view URL

### DIFF
--- a/lib/commands/commands.rb
+++ b/lib/commands/commands.rb
@@ -17,6 +17,15 @@ command :admin do |user|
   end
 end
 
+desc "Open the compare page between 2 refs for this repo in a web browser"
+usage "github compare [start_ref] [end_ref]"
+command :compare do |start_ref, end_ref|
+  if helper.project
+    page = helper.compare_page_for(helper.owner, start_ref, end_ref)
+    helper.open page
+  end
+end
+
 desc "Automatically set configuration info, or pass args to specify."
 usage "github config [my_username] [my_repo_name]"
 command :config do |user, repo|

--- a/lib/commands/helpers.rb
+++ b/lib/commands/helpers.rb
@@ -261,6 +261,10 @@ helper :list_issues_for do |user, state|
   "https://github.com/api/v2/yaml/issues/list/#{user}/#{project}/#{state}"
 end
 
+helper :compare_page_for do |user, start_ref, end_ref|
+  "https://github.com/#{user}/#{project}/compare/#{ [start_ref,end_ref].compact.join('...') }"
+end
+
 helper :has_launchy? do |blk|
   begin
     gem 'launchy'


### PR DESCRIPTION
documented @ https://github.com/blog/612-introducing-github-compare-view

usage:
github compare [start_ref] [end_ref]

opens, in a web browser, the compare view for the passed refs. end_ref
can be omitted to compare to master.
